### PR TITLE
Update crates, edition, and rust version

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "backend"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.95.0"
 
 [dependencies]
 axum = "0.8"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-uuid = { version = "1.0", features = ["v4", "serde"] }
+uuid = { version = "1.23", features = ["v4", "serde"] }

--- a/backend/src/analytics.rs
+++ b/backend/src/analytics.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{Json, extract::State, http::StatusCode};
 use serde::{Deserialize, Serialize};
 use std::{path::Path as FilePath, sync::Arc};
 use tokio::sync::RwLock;

--- a/backend/src/git.rs
+++ b/backend/src/git.rs
@@ -1,7 +1,7 @@
 use axum::{
+    Json,
     extract::{Path, State},
     http::StatusCode,
-    Json,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path as FilePath, sync::Arc};

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,8 +1,8 @@
 use axum::{
+    Json, Router,
     extract::{Path, State},
     http::{Method, StatusCode},
     routing::{delete, get},
-    Json, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::SocketAddr, path::Path as FilePath, sync::Arc};

--- a/backend/src/templates.rs
+++ b/backend/src/templates.rs
@@ -1,7 +1,7 @@
 use axum::{
+    Json,
     extract::{Path, State},
     http::StatusCode,
-    Json,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path as FilePath, sync::Arc};

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "leptos_studio"
 version = "0.1.0"
@@ -9,35 +8,30 @@ repository = "https://github.com/analisaperlengkapan/leptos-studio"
 authors = ["Leptos Studio Contributors"]
 keywords = ["leptos", "wasm", "ui-builder", "webassembly", "rust"]
 categories = ["wasm", "web-programming", "gui"]
-rust-version = "1.90.0"
+rust-version = "1.95.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-leptos = { version = "0.8.14", features = ["csr"] }
-leptos_router = "0.8.10"
-leptos_dom = "0.8.7"
-web-sys = { version = "0.3", features = [
-    "DragEvent", "DataTransfer", "Window", "Storage", "console",
-    "HtmlInputElement", "FileList", "File", "Clipboard", "Navigator",
-    "Element", "HtmlElement", "Event", "EventTarget", "Blob", "BlobPropertyBag", "Url",
-    "FileReader", "DomException", "NodeList", "Node", "Performance"
-] }
+leptos = { version = "0.8.19", features = ["csr"] }
+leptos_router = "0.8.13"
+leptos_dom = "0.8.8"
+web-sys = { version = "0.3.98", features = ["DragEvent", "DataTransfer", "Window", "Storage", "console", "HtmlInputElement", "FileList", "File", "Clipboard", "Navigator", "Element", "HtmlElement", "Event", "EventTarget", "Blob", "BlobPropertyBag", "Url", "FileReader", "DomException", "NodeList", "Node", "Performance"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 console_error_panic_hook = "0.1"
-js-sys = "0.3"
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+js-sys = "0.3.98"
+wasm-bindgen = { version = "0.2.121", features = ["serde-serialize"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
-wasm-bindgen-futures = "0.4"
+wasm-bindgen-futures = "0.4.71"
 gloo-net = "0.7"
 thiserror = "2.0"
-uuid = { version = "1.11", features = ["v4", "serde", "js"] }
-regex = "1.11"
-chrono = { version = "0.4.42", features = ["serde"] }
-futures = "0.3.31"
+uuid = { version = "1.23", features = ["v4", "serde", "js"] }
+regex = "1.12"
+chrono = { version = "0.4.44", features = ["serde"] }
+futures = "0.3.32"
 async-trait = "0.1.89"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.71"


### PR DESCRIPTION
Update all crates to latest versions and upgrade to Rust 2024 (1.95) across backend and frontend.

---
*PR created automatically by Jules for task [11605645494757056999](https://jules.google.com/task/11605645494757056999) started by @analisaperlengkapan*